### PR TITLE
doc(docker-installation): #4445 warning to clarify localhost access

### DIFF
--- a/content/30min-setup.md
+++ b/content/30min-setup.md
@@ -49,9 +49,9 @@ back instance:
 $ ./taiga-manage.sh [COMMAND]
 ```
 
-Default access for the application is **http://localhost:9000**.
+If you're testing it in your own machine, you can access the application in **http://localhost:9000**. If you're deploying in a server, you'll need to configure hosts and nginx as described later.
 
-As **EXTRA**: the default `launch-all.sh` script comes with [penpot](https://penpot.app), the open-source solution for design and prototyping. The default access for the penpot application is **http://locahost:9001**
+As **EXTRA**: the default `launch-all.sh` script comes with [penpot](https://penpot.app), the open-source solution for design and prototyping. The default same machine access for the penpot application is **http://locahost:9001**
 
 It's developed by the same team behind Taiga. If you want to give it a try, you can go to [penpot's github](https://github.com/penpot/penpot/tree/develop/docs) to review its own configuration variables.
 


### PR DESCRIPTION
Includes a warning in the docker installation guide, to clarify the default localhost:9000 access.
- Original issue https://github.com/taigaio/taiga-docker/issues/69
- Taiga's issue: https://tree.taiga.io/project/taiga/issue/4445

> **WARNING**: This PR should be merged in conjunction with:
https://github.com/kaleidos-ventures/taiga-docker/pull/1
https://github.com/kaleidos-ventures/taiga-doc/pull/1

![gif](https://media.giphy.com/media/lOgzjLU2mmN3VoUG4S/giphy.gif)